### PR TITLE
Displays KitClient Ready message

### DIFF
--- a/.devcontainer/installKitFeatures.bash
+++ b/.devcontainer/installKitFeatures.bash
@@ -6,4 +6,5 @@ if [ -d .kit ] && [ "$(pwd)" != "/home/$USER" ]; then
 fi
 
 # Run a new shell to pickup the changes.
+echo "KitClient is ready for use."
 exec /bin/bash

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A KitClient that runs in GitHub Codespaces.
       - If you have multiple KitClients created from HFOSSedu/KitClient-Codespace, and want to pick one of them, visit your [Codespaces page](https://github.com/codespaces).
    2. A new browser window or tab will open where the KitClient will load.
    3. Wait for the KitClient to become ready for use.
-      - The message "KitClient Ready for use." will be displayed when the KitClient is ready.
+      - The message "KitClient Ready for use." will be displayed in the terminal when the KitClient is ready.
       - Creating a new KitClient can take several minutes. 
         - You will see the screen contents change several times.
         - Eventually a prompt asking you to "Paste you GitHub Personal Access Token (PAT) here:" will appear.

--- a/README.md
+++ b/README.md
@@ -14,14 +14,13 @@ A KitClient that runs in GitHub Codespaces.
       - If you have multiple KitClients created from HFOSSedu/KitClient-Codespace, and want to pick one of them, visit your [Codespaces page](https://github.com/codespaces).
    2. A new browser window or tab will open where the KitClient will load.
    3. Wait for the KitClient to become ready for use.
+      - The message "KitClient Ready for use." will be displayed when the KitClient is ready.
       - Creating a new KitClient can take several minutes. 
         - You will see the screen contents change several times.
         - Eventually a prompt asking you to "Paste you GitHub Personal Access Token (PAT) here:" will appear.
         - [Create a new PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#creating-a-personal-access-token-classic) or use an existing one with the `Repo` option for "scopes and permissions".
         - Paste the PAT at the prompt and press enter.  Note that your PAT will not be displayed when you paste it.
-        - Your new KitClient is ready for use when you see the prompt with your GitHub username in the terminal.
       - Restarting an existing KitClient requires much less time.
-        - An existing KitClient is ready when it returns to the state that it was in when you last stopped it.
 
 ## Stopping the KitClient
 


### PR DESCRIPTION
The KitClient now displays the message "KitClient ready for use." in the terminal when the startup process has completed.

Closes HFOSSedu/GitKit-Text#104